### PR TITLE
Add missing `_` (underscore) so C11 variant builds

### DIFF
--- a/once.h
+++ b/once.h
@@ -23,7 +23,7 @@
 #  elif defined(__has_include)
 #    if __has_include(<threads.h>)
 #      include <threads.h>
-#      define PSNIP_ONCE_BACKEND PSNIP_ONCE_BACKEND_C11
+#      define PSNIP_ONCE_BACKEND PSNIP_ONCE__BACKEND_C11
 #    endif
 #  elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201102L) && !defined(__STDC_NO_THREADS__)
 #    include <limits.h>
@@ -33,7 +33,7 @@
    first check doesn't work. */
 #    else
 #      include <threads.h>
-#      define PSNIP_ONCE_BACKEND PSNIP_ONCE_BACKEND_C11
+#      define PSNIP_ONCE_BACKEND PSNIP_ONCE__BACKEND_C11
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
Without this, fails with:
```
cc -MMD -Wall -Wextra  -g -O2 -c -std=c11 -o cpu.o cpu.c
cpu.c:48:8: error: unknown type name ‘psnip_once’
 static psnip_once psnip_cpu_once = PSNIP_ONCE_INIT;
        ^~~~~~~~~~
cpu.c:48:36: error: ‘PSNIP_ONCE_INIT’ undeclared here (not in a function); did you mean ‘PSNIP_ONCE__H’?
 static psnip_once psnip_cpu_once = PSNIP_ONCE_INIT;
                                    ^~~~~~~~~~~~~~~
                                    PSNIP_ONCE__H
cpu.c: In function ‘psnip_cpu_feature_check’:
cpu.c:91:3: warning: implicit declaration of function ‘psnip_once_call’ [-Wimplicit-function-declaration]
   psnip_once_call (&psnip_cpu_once, psnip_cpu_init);
   ^~~~~~~~~~~~~~~
make: *** [Makefile:51: cpu.o] Error 1
```