### PR TITLE
Tweak widths of 'Mops' and 'A/M-ratio' columns

### DIFF
--- a/avx-turbo.cpp
+++ b/avx-turbo.cpp
@@ -708,9 +708,9 @@ void report_results(const std::vector<result_holder>& results_list, bool use_ape
                                 .addf("%5.3f", holder.get_overlap3());
 
         auto& results = holder.results;
-        row.add(result_string(results, "%4.0f", [](const result& r){ return r.inner.mops * 1000; }));
+        row.add(result_string(results, "%5.0f", [](const result& r){ return r.inner.mops * 1000; }));
         if (use_aperf) {
-            row.add(result_string(results, "%5.2f", [](const result& r){ return r.aperf_am; }));
+            row.add(result_string(results, "%4.2f", [](const result& r){ return r.aperf_am; }));
             row.add(result_string(results, "%.0f",  [](const result& r){ return r.aperf_am / 1000000.0 * RdtscClock::tsc_freq(); }));
             row.add(result_string(results, "%4.2f", [](const result& r){ return r.aperf_mt; }));
         }


### PR DESCRIPTION
"Mops" can hit 5 columns wide for add and xor causing poor alignment. "A/M ratio" will never hit 10.0, so reclaim that extra column of space.

Before:
![image](https://github.com/travisdowns/avx-turbo/assets/19476302/ef3acb52-dcb9-473a-8199-fab0449ce169)

After:
![image](https://github.com/travisdowns/avx-turbo/assets/19476302/c9d6a1db-7193-49ad-bc83-e75583cdb4d4)
