### PR TITLE
use fixed CPU number to determine if APERF/MPERF are supported

### DIFF
--- a/avx-turbo.cpp
+++ b/avx-turbo.cpp
@@ -279,8 +279,8 @@ struct aperf_ghz : outer_timer {
      */
     static bool is_supported() {
         uint64_t dummy;
-        return     read_msr_cur_cpu(MSR_IA32_MPERF, &dummy) == 0
-                && read_msr_cur_cpu(MSR_IA32_APERF, &dummy) == 0;
+        return     read_msr(1, MSR_IA32_MPERF, &dummy) == 0
+                && read_msr(1, MSR_IA32_APERF, &dummy) == 0;
     }
 
     virtual void start() override {


### PR DESCRIPTION
This pull request includes a small change to the `avx-turbo.cpp` file. The change updates the `is_supported()` method to use the `read_msr` function with a CPU index of `1` instead of the `read_msr_cur_cpu` function.

I've found that the `is_supported()` function while using `read_msr_cur_cpu()` does not consistently return true on the same system. By always reading from a fixed CPU number, it is consistent.

Determining the availability of MPERF and APERF doesn't require reading the MSR from the CPU that is currently running avx-turbo.